### PR TITLE
Moving to Alpine image + Autobuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-MAINTAINER d3vilh@github
-LABEL rpi_exporter.author="cavaliercoder@github"
-FROM arm64v8/debian
-ARG OS=linux
-ARG ARCH=arm64v8
-ARG DEBIAN_FRONTEND=noninteractive
+FROM arm64v8/alpine as build
+RUN apk update && apk add --no-cache make go
+WORKDIR /opt
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN make 
+###
+FROM arm64v8/alpine 
+LABEL rpi_exporter.author="cavaliercoder@github" maintainer="Mr.Philipp <d3vilh@github.com>"
 EXPOSE 9110
 WORKDIR /opt
-ADD rpi_exporter /opt/rpi_exporter
-RUN chmod +x /opt/rpi_exporter
-ENTRYPOINT /opt/rpi_exporter -addr=:9110
+COPY --from=build /opt/rpi_exporter /opt
+CMD ["./rpi_exporter", "-addr=:9110"]

--- a/README.md
+++ b/README.md
@@ -61,3 +61,8 @@ scrape_configs:
 ```shell
 $ sudo systemctl restart prometheus.service
 ```
+
+## Build Docker image
+```shell
+docker build --force-rm=true -t rpi_exporter-arm64 .
+```


### PR DESCRIPTION
Moved to Alpine Linux base image (from Debian) to reduce container image size 10 times:

```bash
philipp@d3vpi:~/build/rpi_export $ docker image ls | grep rpi_exporter | grep -E 'alpine|debian'
d3vilh/rpi_exporter-arm64              alpine        aa0aadc1ef01   13 minutes ago   13.9MB
d3vilh/rpi_exporter-arm64              debian        d50133320582   7 weeks ago      129MB
philipp@d3vpi:~/build/rpi_export $
```

Also I include building of binary inside the container. To build you just need to run:
```bash
docker build --force-rm=true -t rpi_exporter-arm64 .
```
 and then test:

```bash
docker run --interactive --tty --rm rpi_exporter-arm64
```

compose file is the same.